### PR TITLE
fix: Path parameters are not validated properly when they are encoded

### DIFF
--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -118,6 +118,10 @@ func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options
 	if err != nil {
 		switch e := err.(type) {
 		case *routers.RouteError:
+			// The path may exist on the server, but the method is not allowed.
+			if errors.Is(e, routers.ErrMethodNotAllowed) {
+				return echo.NewHTTPError(http.StatusMethodNotAllowed, e.Reason)
+			}
 			// We've got a bad request, the path requested doesn't match
 			// either server, or path, or something.
 			return echo.NewHTTPError(http.StatusNotFound, e.Reason)

--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -125,6 +126,14 @@ func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options
 			// we don't want to crash the server, so handle the unexpected error.
 			return echo.NewHTTPError(http.StatusInternalServerError,
 				fmt.Sprintf("error validating route: %s", err.Error()))
+		}
+	}
+
+	// because gorillamux.NewRouter() uses mux.NewRouter().UseEncodedPath()
+	// we need to unescape the path parameters for openapi3filter
+	for k, v := range pathParams {
+		if v, err := url.PathUnescape(v); err == nil {
+			pathParams[k] = v
 		}
 	}
 

--- a/test_spec.yaml
+++ b/test_spec.yaml
@@ -16,7 +16,7 @@ paths:
             minimum: 10
             maximum: 100
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:
@@ -29,7 +29,7 @@ paths:
     post:
       operationId: createResource
       responses:
-        '204':
+        "204":
           description: No content
       requestBody:
         required: true
@@ -39,6 +39,32 @@ paths:
               properties:
                 name:
                   type: string
+  /resource/maxlength/{param}:
+    get:
+      operationId: getMaxLengthResourceParameter
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: string
+            maxLength: 1
+      responses:
+        "204":
+          description: success
+  /resource/pattern/{param}:
+    get:
+      operationId: getPatternResourceParameter
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^\+[1-9]+$'
+      responses:
+        "204":
+          description: success
   /protected_resource:
     get:
       operationId: getProtectedResource
@@ -46,7 +72,7 @@ paths:
         - BearerAuth:
             - someScope
       responses:
-        '204':
+        "204":
           description: no content
   /protected_resource2:
     get:
@@ -55,7 +81,7 @@ paths:
         - BearerAuth:
             - otherScope
       responses:
-        '204':
+        "204":
           description: no content
   /protected_resource_401:
     get:
@@ -64,7 +90,7 @@ paths:
         - BearerAuth:
             - unauthorized
       responses:
-        '401':
+        "401":
           description: no content
   /multiparamresource:
     get:
@@ -85,7 +111,7 @@ paths:
             minimum: 10
             maximum: 100
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:


### PR DESCRIPTION
Fixes #17 

Parameters should be unscaped before being sent for validation.

gorillamux returns escaped parameters, but openapi3filter expects unescaped parameters.