### PR TITLE
feat: add Prefix option for sub-path mounted APIs

### DIFF
--- a/oapi_validate_test.go
+++ b/oapi_validate_test.go
@@ -117,14 +117,14 @@ func TestOapiRequestValidator(t *testing.T) {
 	})
 	// Let's send the request to the wrong server, this should return 404
 	{
-		rec := doGet(t, e, "http://not.deepmap.ai/resource")
+		rec := doGet(t, e, "http://not.test.hostname/resource")
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 	}
 
 	// Let's send a good request, it should pass
 	{
-		rec := doGet(t, e, "http://deepmap.ai/resource")
+		rec := doGet(t, e, "http://test.hostname/resource")
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.True(t, called, "Handler should have been called")
 		called = false
@@ -132,7 +132,7 @@ func TestOapiRequestValidator(t *testing.T) {
 
 	// Send an out-of-spec parameter
 	{
-		rec := doGet(t, e, "http://deepmap.ai/resource?id=500")
+		rec := doGet(t, e, "http://test.hostname/resource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
@@ -140,7 +140,7 @@ func TestOapiRequestValidator(t *testing.T) {
 
 	// Send a bad parameter type
 	{
-		rec := doGet(t, e, "http://deepmap.ai/resource?id=foo")
+		rec := doGet(t, e, "http://test.hostname/resource?id=foo")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
@@ -148,7 +148,7 @@ func TestOapiRequestValidator(t *testing.T) {
 
 	// Send a request with the wrong HTTP method
 	{
-		rec := doPost(t, e, "http://deepmap.ai/multiparamresource", nil)
+		rec := doPost(t, e, "http://test.hostname/multiparamresource", nil)
 		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
@@ -168,7 +168,7 @@ func TestOapiRequestValidator(t *testing.T) {
 		}{
 			Name: "Marcin",
 		}
-		rec := doPost(t, e, "http://deepmap.ai/resource", body)
+		rec := doPost(t, e, "http://test.hostname/resource", body)
 		assert.Equal(t, http.StatusNoContent, rec.Code)
 		assert.True(t, called, "Handler should have been called")
 		called = false
@@ -181,7 +181,7 @@ func TestOapiRequestValidator(t *testing.T) {
 		}{
 			Name: 7,
 		}
-		rec := doPost(t, e, "http://deepmap.ai/resource", body)
+		rec := doPost(t, e, "http://test.hostname/resource", body)
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
@@ -195,7 +195,7 @@ func TestOapiRequestValidator(t *testing.T) {
 
 	// Call a protected function to which we have access
 	{
-		rec := doGet(t, e, "http://deepmap.ai/protected_resource")
+		rec := doGet(t, e, "http://test.hostname/protected_resource")
 		assert.Equal(t, http.StatusNoContent, rec.Code)
 		assert.True(t, called, "Handler should have been called")
 		called = false
@@ -207,7 +207,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	})
 	// Call a protected function to which we dont have access
 	{
-		rec := doGet(t, e, "http://deepmap.ai/protected_resource2")
+		rec := doGet(t, e, "http://test.hostname/protected_resource2")
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
@@ -219,7 +219,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	})
 	// Call a protected function without credentials
 	{
-		rec := doGet(t, e, "http://deepmap.ai/protected_resource_401")
+		rec := doGet(t, e, "http://test.hostname/protected_resource_401")
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.Equal(t, "test: code=401, message=Unauthorized", rec.Body.String())
 		assert.False(t, called, "Handler should not have been called")
@@ -259,7 +259,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 
 	// Let's send a good request, it should pass
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50&id2=50")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=50&id2=50")
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.True(t, called, "Handler should have been called")
 		called = false
@@ -268,7 +268,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	// Let's send a request with a missing parameter, it should return
 	// a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=50")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -282,7 +282,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	// Let's send a request with a 2 missing parameters, it should return
 	// a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -298,7 +298,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	// Let's send a request with a 1 missing parameter, and another outside
 	// or the parameters. It should return a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=500")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -314,7 +314,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	// Let's send a request with a parameters that do not meet spec. It should
 	// return a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -367,7 +367,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 
 	// Let's send a good request, it should pass
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50&id2=50")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=50&id2=50")
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.True(t, called, "Handler should have been called")
 		called = false
@@ -376,7 +376,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	// Let's send a request with a missing parameter, it should return
 	// a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=50")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -390,7 +390,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	// Let's send a request with a 2 missing parameters, it should return
 	// a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -406,7 +406,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	// Let's send a request with a 1 missing parameter, and another outside
 	// or the parameters. It should return a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=500")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=500")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -422,7 +422,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	// Let's send a request with a parameters that do not meet spec. It should
 	// return a bad status
 	{
-		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
+		rec := doGet(t, e, "http://test.hostname/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
 		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
@@ -433,6 +433,55 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 		}
 		assert.False(t, called, "Handler should not have been called")
 		called = false
+	}
+}
+
+func TestOapiRequestValidatorWithPrefix(t *testing.T) {
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
+
+	// Create a new echo router
+	e := echo.New()
+
+	options := Options{
+		SilenceServersWarning: true,
+		Prefix:                "/api",
+	}
+
+	// Install our OpenApi based request validator
+	e.Use(OapiRequestValidatorWithOptions(spec, &options))
+
+	called := false
+
+	// Register handler under the prefixed path (as echo sees it)
+	e.GET("/api/resource", func(c echo.Context) error {
+		called = true
+		// The original request path should be preserved for the handler
+		assert.Equal(t, "/api/resource", c.Request().URL.Path)
+		return c.NoContent(http.StatusOK)
+	})
+
+	// A request to /api/resource should validate against /resource in the spec
+	{
+		rec := doGet(t, e, "http://test.hostname/api/resource")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, called, "Handler should have been called")
+		called = false
+	}
+
+	// A request with query params should also validate correctly
+	{
+		rec := doGet(t, e, "http://test.hostname/api/resource?id=50")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, called, "Handler should have been called")
+		called = false
+	}
+
+	// An out-of-spec parameter should still be rejected
+	{
+		rec := doGet(t, e, "http://test.hostname/api/resource?id=500")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
 	}
 }
 

--- a/test_spec.yaml
+++ b/test_spec.yaml
@@ -3,7 +3,7 @@ info:
   version: 1.0.0
   title: TestServer
 servers:
-  - url: http://deepmap.ai
+  - url: http://test.hostname
 paths:
   /resource:
     get:


### PR DESCRIPTION
Add a Prefix field to Options that strips a path prefix before OpenAPI validation. This allows APIs mounted under a sub-path (e.g. "/api") to validate correctly against specs whose paths don't include the prefix.

The request is cloned before modification so downstream handlers still see the original path.

Closes #11
Supersedes #15