### PR TITLE
fix: unescape URL-encoded path params before OpenAPI validation

### DIFF
--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -155,6 +156,15 @@ func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options
 			// we don't want to crash the server, so handle the unexpected error.
 			return echo.NewHTTPError(http.StatusInternalServerError,
 				fmt.Sprintf("error validating route: %s", err.Error()))
+		}
+	}
+
+	// gorillamux uses UseEncodedPath(), so path parameters are returned in
+	// their percent-encoded form. Unescape them before passing to
+	// openapi3filter, which expects decoded values.
+	for k, v := range pathParams {
+		if unescaped, err := url.PathUnescape(v); err == nil {
+			pathParams[k] = unescaped
 		}
 	}
 

--- a/test_spec.yaml
+++ b/test_spec.yaml
@@ -39,6 +39,32 @@ paths:
               properties:
                 name:
                   type: string
+  /resource/maxlength/{param}:
+    get:
+      operationId: getMaxLengthResourceParameter
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: string
+            maxLength: 1
+      responses:
+        '204':
+          description: success
+  /resource/pattern/{param}:
+    get:
+      operationId: getPatternResourceParameter
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^\+[0-9]+$'
+      responses:
+        '204':
+          description: success
   /protected_resource:
     get:
       operationId: getProtectedResource


### PR DESCRIPTION
gorillamux uses UseEncodedPath(), so FindRoute() returns path parameters in percent-encoded form. openapi3filter expects decoded values, which causes validation of constraints like maxLength and pattern to fail on encoded input (e.g. %2B is 3 chars but decodes to 1 char).

Unescape path parameters after route matching and before passing them to openapi3filter.

Fixes #17
Supersedes #18